### PR TITLE
Feature

### DIFF
--- a/PROXIES.md
+++ b/PROXIES.md
@@ -4,6 +4,7 @@
 - [php](./php.bat)
 - [composer](./composer.bat)
 - phpcs-composer(./phpcs-composer.bat)
+- phpcs.phar(./phpcs.phar.bat)
 
 #### Haskell
 - [ghc](./ghc.bat)

--- a/PROXIES.md
+++ b/PROXIES.md
@@ -3,6 +3,7 @@
 #### PHP
 - [php](./php.bat)
 - [composer](./composer.bat)
+- phpcs-composer(./phpcs-composer.bat)
 
 #### Haskell
 - [ghc](./ghc.bat)

--- a/PROXIES.md
+++ b/PROXIES.md
@@ -3,8 +3,9 @@
 #### PHP
 - [php](./php.bat)
 - [composer](./composer.bat)
-- phpcs-composer(./phpcs-composer.bat)
-- phpcs.phar(./phpcs.phar.bat)
+- [phpcs-composer](./phpcs-composer.bat)
+- [phpcs.phar](./phpcs.phar.bat)
+- [phpcs](./phpcs.bat)
 
 #### Haskell
 - [ghc](./ghc.bat)

--- a/phpcs-composer.bat
+++ b/phpcs-composer.bat
@@ -1,0 +1,2 @@
+@echo off
+bash.exe -c "~/.composer/vendor/bin/phpcs %*"

--- a/phpcs.bat
+++ b/phpcs.bat
@@ -1,0 +1,2 @@
+@echo off
+bash.exe -c "phpcs %*"

--- a/phpcs.phar.bat
+++ b/phpcs.phar.bat
@@ -1,0 +1,2 @@
+@echo off
+bash.exe -c "php phpcs.phar %*"


### PR DESCRIPTION
Added `phpcs`.

There are 3 general ways to use phpcs (from [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer/blob/master/README.md)):
1) if downloaded `.phar` file, then run `php phpcs.phar` (`phpcs.phar.bat`)
2) if used PEAR, then it avialable from command line with `phpcs` command (`phpcs.bat`)
3) if installed from Composer, run PHP_CodeSniffer from the vendor bin directory (`phpcs-composer.bat`)